### PR TITLE
Only set followlocation if safemode and open_basedir are not set

### DIFF
--- a/src/Unirest/Unirest.php
+++ b/src/Unirest/Unirest.php
@@ -364,7 +364,6 @@ class Unirest
         curl_setopt_array(self::$handle, array(
             CURLOPT_URL => self::encodeUrl($request->url),
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 10,
             CURLOPT_HTTPHEADER => self::getFormattedHeaders($request->headers),
             CURLOPT_HEADER => true,
@@ -372,6 +371,10 @@ class Unirest
             // If an empty string, '', is set, a header containing all supported encoding types is sent
             CURLOPT_ENCODING => ''
         ));
+
+	if (strtolower(ini_get('safe_mode')) == 'off' && ini_get('open_basedir') == '') {
+            curl_setopt(self::$handle, CURLOPT_FOLLOWLOCATION, true);
+	}
 
         if (self::$socketTimeout !== null) {
             curl_setopt(self::$handle, CURLOPT_TIMEOUT, self::$socketTimeout);


### PR DESCRIPTION
If open_basedir is set, or safe_mode is enabled, then the following error is thrown when attempting to enable FOLLOWLOCATION;

> PHP Warning:  curl_setopt_array(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set

I have just added a check to make sure neither of those options are set.