### PR TITLE
fix(invalid-content-type): default content-type for null request body

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -58,6 +58,7 @@ class HttpClient implements HttpClientInterface
             if (empty($error)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
+                var_dump($response, $error);
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));
             }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -58,7 +58,7 @@ class HttpClient implements HttpClientInterface
             if (empty($error)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
-                var_dump($request, $response);
+                var_dump($this->getInfo(CURLOPT_URL), $response);
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));
             }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -121,7 +121,10 @@ class HttpClient implements HttpClientInterface
                 }
                 curl_setopt($handle, CURLOPT_CUSTOMREQUEST, strtoupper($request->getHttpMethod()));
             }
-            curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
+
+            if (!is_null($body)) {
+                curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
+            }
         } elseif (is_array($body)) {
             if (strpos($queryUrl, '?') !== false) {
                 $queryUrl .= '&';

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -58,7 +58,7 @@ class HttpClient implements HttpClientInterface
             if (empty($error)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
-                var_dump($response, $error);
+                var_dump($request, $response);
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));
             }
 

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -58,7 +58,6 @@ class HttpClient implements HttpClientInterface
             if (empty($error)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
-                var_dump($response);
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));
             }
 
@@ -134,7 +133,6 @@ class HttpClient implements HttpClientInterface
             }
             $queryUrl .= http_build_query(Request::buildHTTPCurlQuery($body));
         }
-        print_r("Query URL: $queryUrl");
 
         $curl_base_options = [
             CURLOPT_URL => $queryUrl,

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -58,7 +58,7 @@ class HttpClient implements HttpClientInterface
             if (empty($error)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
-                var_dump($this->getInfo(CURLOPT_URL), $response);
+                var_dump($response);
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));
             }
 
@@ -134,6 +134,8 @@ class HttpClient implements HttpClientInterface
             }
             $queryUrl .= urldecode(http_build_query(Request::buildHTTPCurlQuery($body)));
         }
+        print_r("Query URL: $queryUrl");
+
         $curl_base_options = [
             CURLOPT_URL => $queryUrl,
             CURLOPT_RETURNTRANSFER => true,

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -132,7 +132,7 @@ class HttpClient implements HttpClientInterface
             } else {
                 $queryUrl .= '?';
             }
-            $queryUrl .= urldecode(http_build_query(Request::buildHTTPCurlQuery($body)));
+            $queryUrl .= http_build_query(Request::buildHTTPCurlQuery($body));
         }
         print_r("Query URL: $queryUrl");
 


### PR DESCRIPTION
This PR bears a fix for the default `content-type` header when the request body is not present. This commit fixes the issue by allowing the body to be set in the request when it is not null.

closes #37 