### PR TITLE
fix(curl): handle non-string response from curl_exec

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -55,7 +55,7 @@ class HttpClient implements HttpClientInterface
             $response  = curl_exec($this->handle);
             $error     = curl_error($this->handle);
             $info      = $this->getInfo();
-            if (empty($error)) {
+            if (empty($error) && is_string($response)) {
                 $header_size = $info['header_size'];
                 $httpCode    = (int)$info['http_code'];
                 $headers     = $this->parseHeaders(substr($response, 0, $header_size));


### PR DESCRIPTION
## What
Added a check to ensure curl_exec response is a string before processing to prevent potential fatal errors.

## Why
curl_exec can return non-string values on failure, which could cause fatal errors if not handled.

Closes #59 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
