### PR TITLE
 fix(post-request): handle empty body

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -107,11 +107,11 @@ class HttpClient implements HttpClientInterface
         }
         return $multipartParameters;
     }
-
     protected function setCurlOptions($handle, RequestInterface $request): void
     {
         $queryUrl = $request->getQueryUrl();
         $body = $this->getBody($request);
+
         if ($request->getHttpMethod() !== RequestMethod::GET) {
             if ($request->getHttpMethod() === RequestMethod::POST) {
                 curl_setopt($handle, CURLOPT_POST, true);
@@ -121,6 +121,10 @@ class HttpClient implements HttpClientInterface
                     curl_setopt($handle, CURLOPT_NOBODY, true);
                 }
                 curl_setopt($handle, CURLOPT_CUSTOMREQUEST, strtoupper($request->getHttpMethod()));
+
+                if (!is_null($body)) {
+                    curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
+                }
             }
         } elseif (is_array($body)) {
             if (strpos($queryUrl, '?') !== false) {
@@ -139,10 +143,7 @@ class HttpClient implements HttpClientInterface
             CURLOPT_HTTPHEADER => $this->getFormattedHeaders($request),
             CURLOPT_HEADER => true,
             CURLOPT_SSL_VERIFYPEER => $this->config->shouldVerifyPeer(),
-            // CURLOPT_SSL_VERIFYHOST accepts only 0 (false) or 2 (true).
-            // Future versions of libcurl will treat values 1 and 2 as equals
             CURLOPT_SSL_VERIFYHOST => $this->config->shouldVerifyHost() === false ? 0 : 2,
-            // If an empty string, '', is set, a header containing all supported encoding types is sent
             CURLOPT_ENCODING => ''
         ];
 
@@ -163,20 +164,20 @@ class HttpClient implements HttpClientInterface
 
         if (!empty($this->config->getAuth()['user'])) {
             curl_setopt_array($handle, [
-                CURLOPT_HTTPAUTH    => $this->config->getAuth()['method'],
-                CURLOPT_USERPWD     => $this->config->getAuth()['user'] . ':' . $this->config->getAuth()['pass']
+                CURLOPT_HTTPAUTH => $this->config->getAuth()['method'],
+                CURLOPT_USERPWD => $this->config->getAuth()['user'] . ':' . $this->config->getAuth()['pass']
             ]);
         }
 
         $proxy = $this->config->getProxy();
         if (!empty($proxy['address'])) {
             curl_setopt_array($handle, [
-                CURLOPT_PROXYTYPE       => $proxy['type'],
-                CURLOPT_PROXY           => $proxy['address'],
-                CURLOPT_PROXYPORT       => $proxy['port'],
+                CURLOPT_PROXYTYPE => $proxy['type'],
+                CURLOPT_PROXY => $proxy['address'],
+                CURLOPT_PROXYPORT => $proxy['port'],
                 CURLOPT_HTTPPROXYTUNNEL => $proxy['tunnel'],
-                CURLOPT_PROXYAUTH       => $proxy['auth']['method'],
-                CURLOPT_PROXYUSERPWD    => $proxy['auth']['user'] . ':' . $proxy['auth']['pass']
+                CURLOPT_PROXYAUTH => $proxy['auth']['method'],
+                CURLOPT_PROXYUSERPWD => $proxy['auth']['user'] . ':' . $proxy['auth']['pass']
             ]);
         }
     }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -111,7 +111,6 @@ class HttpClient implements HttpClientInterface
     {
         $queryUrl = $request->getQueryUrl();
         $body = $this->getBody($request);
-
         if ($request->getHttpMethod() !== RequestMethod::GET) {
             if ($request->getHttpMethod() === RequestMethod::POST) {
                 curl_setopt($handle, CURLOPT_POST, true);
@@ -121,7 +120,6 @@ class HttpClient implements HttpClientInterface
                     curl_setopt($handle, CURLOPT_NOBODY, true);
                 }
                 curl_setopt($handle, CURLOPT_CUSTOMREQUEST, strtoupper($request->getHttpMethod()));
-
                 if (!is_null($body)) {
                     curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
                 }
@@ -143,7 +141,10 @@ class HttpClient implements HttpClientInterface
             CURLOPT_HTTPHEADER => $this->getFormattedHeaders($request),
             CURLOPT_HEADER => true,
             CURLOPT_SSL_VERIFYPEER => $this->config->shouldVerifyPeer(),
+            // CURLOPT_SSL_VERIFYHOST accepts only 0 (false) or 2 (true).
+            // Future versions of libcurl will treat values 1 and 2 as equals
             CURLOPT_SSL_VERIFYHOST => $this->config->shouldVerifyHost() === false ? 0 : 2,
+            // If an empty string, '', is set, a header containing all supported encoding types is sent
             CURLOPT_ENCODING => ''
         ];
 
@@ -164,20 +165,20 @@ class HttpClient implements HttpClientInterface
 
         if (!empty($this->config->getAuth()['user'])) {
             curl_setopt_array($handle, [
-                CURLOPT_HTTPAUTH => $this->config->getAuth()['method'],
-                CURLOPT_USERPWD => $this->config->getAuth()['user'] . ':' . $this->config->getAuth()['pass']
+                CURLOPT_HTTPAUTH    => $this->config->getAuth()['method'],
+                CURLOPT_USERPWD     => $this->config->getAuth()['user'] . ':' . $this->config->getAuth()['pass']
             ]);
         }
 
         $proxy = $this->config->getProxy();
         if (!empty($proxy['address'])) {
             curl_setopt_array($handle, [
-                CURLOPT_PROXYTYPE => $proxy['type'],
-                CURLOPT_PROXY => $proxy['address'],
-                CURLOPT_PROXYPORT => $proxy['port'],
+                CURLOPT_PROXYTYPE       => $proxy['type'],
+                CURLOPT_PROXY           => $proxy['address'],
+                CURLOPT_PROXYPORT       => $proxy['port'],
                 CURLOPT_HTTPPROXYTUNNEL => $proxy['tunnel'],
-                CURLOPT_PROXYAUTH => $proxy['auth']['method'],
-                CURLOPT_PROXYUSERPWD => $proxy['auth']['user'] . ':' . $proxy['auth']['pass']
+                CURLOPT_PROXYAUTH       => $proxy['auth']['method'],
+                CURLOPT_PROXYUSERPWD    => $proxy['auth']['user'] . ':' . $proxy['auth']['pass']
             ]);
         }
     }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -115,15 +115,12 @@ class HttpClient implements HttpClientInterface
         if ($request->getHttpMethod() !== RequestMethod::GET) {
             if ($request->getHttpMethod() === RequestMethod::POST) {
                 curl_setopt($handle, CURLOPT_POST, true);
+                curl_setopt($handle, CURLOPT_POSTFIELDS, is_null($body) ? [] : $body);
             } else {
                 if ($request->getHttpMethod() === RequestMethod::HEAD) {
                     curl_setopt($handle, CURLOPT_NOBODY, true);
                 }
                 curl_setopt($handle, CURLOPT_CUSTOMREQUEST, strtoupper($request->getHttpMethod()));
-            }
-
-            if (!is_null($body)) {
-                curl_setopt($handle, CURLOPT_POSTFIELDS, $body);
             }
         } elseif (is_array($body)) {
             if (strpos($queryUrl, '?') !== false) {


### PR DESCRIPTION
## What
Added a cURL option to always set CURLOPT_POSTFIELDS for POST requests, ensuring the Content-Length header is properly set even when the request body is empty.

## Why
Without setting CURLOPT_POSTFIELDS for empty POST requests, the Content-Length header was missing, causing a 411 Length Required error when sending requests to APIs behind Cloudflare.

Closes #57 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
