### PR TITLE
PHP array_merge merges arrays, which will cause the array key to be lost

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -217,7 +217,7 @@ class Configuration
      */
     public function curlOpts(array $options): self
     {
-        $this->curlOpts = array_merge($this->curlOpts, $options);
+        $this->curlOpts = $this->curlOpts + $options;
         return $this;
     }
 


### PR DESCRIPTION

```
$curlOpts = [];
$options = [10022 => "foo=bar" ];
$result = array_merge($curlOpts, $options);
var_dump($result);
```

result:
```
array(1) { [0]=> string(7) "foo=bar" }
```

array key 10022 is lost